### PR TITLE
fix breaking changes introduced in cloudflare/cloudflare-go

### DIFF
--- a/cloudflare/resource_cloudflare_access_application.go
+++ b/cloudflare/resource_cloudflare_access_application.go
@@ -40,7 +40,6 @@ func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.Re
 		EnableBindingCookie:     d.Get("enable_binding_cookie").(bool),
 		CustomDenyMessage:       d.Get("custom_deny_message").(string),
 		CustomDenyURL:           d.Get("custom_deny_url").(string),
-		HttpOnlyCookieAttribute: d.Get("http_only_cookie_attribute").(bool),
 		SameSiteCookieAttribute: d.Get("same_site_cookie_attribute").(string),
 		LogoURL:                 d.Get("logo_url").(string),
 		SkipInterstitial:        d.Get("skip_interstitial").(bool),
@@ -49,7 +48,8 @@ func resourceCloudflareAccessApplicationCreate(ctx context.Context, d *schema.Re
 	}
 
 	if value, ok := d.GetOk("http_only_cookie_attribute"); ok {
-		newAccessApplication.HttpOnlyCookieAttribute = value.(bool)
+		val := value.(bool)
+		newAccessApplication.HttpOnlyCookieAttribute = &val
 	}
 
 	if len(allowedIDPList) > 0 {
@@ -151,12 +151,16 @@ func resourceCloudflareAccessApplicationUpdate(ctx context.Context, d *schema.Re
 		EnableBindingCookie:     d.Get("enable_binding_cookie").(bool),
 		CustomDenyMessage:       d.Get("custom_deny_message").(string),
 		CustomDenyURL:           d.Get("custom_deny_url").(string),
-		HttpOnlyCookieAttribute: d.Get("http_only_cookie_attribute").(bool),
 		SameSiteCookieAttribute: d.Get("same_site_cookie_attribute").(string),
 		LogoURL:                 d.Get("logo_url").(string),
 		SkipInterstitial:        d.Get("skip_interstitial").(bool),
 		AppLauncherVisible:      d.Get("app_launcher_visible").(bool),
 		ServiceAuth401Redirect:  d.Get("service_auth_401_redirect").(bool),
+	}
+
+	if value, ok := d.GetOk("http_only_cookie_attribute"); ok {
+		val := value.(bool)
+		updatedAccessApplication.HttpOnlyCookieAttribute = &val
 	}
 
 	if len(allowedIDPList) > 0 {

--- a/cloudflare/resource_cloudflare_waiting_room_event.go
+++ b/cloudflare/resource_cloudflare_waiting_room_event.go
@@ -54,7 +54,7 @@ func expandWaitingRoomEvent(d *schema.ResourceData) (cloudflare.WaitingRoomEvent
 		Name:                  d.Get("name").(string),
 		EventStartTime:        eventStartTime,
 		EventEndTime:          eventEndTime,
-		PrequeueStartTime:     prequeueStartTime,
+		PrequeueStartTime:     &prequeueStartTime,
 		Description:           d.Get("description").(string),
 		QueueingMethod:        d.Get("queueing_method").(string),
 		ShuffleAtEventStart:   d.Get("shuffle_at_event_start").(bool),


### PR DESCRIPTION
Related: https://github.com/Shopify/terraform-provider-cloudflare/pull/37

`cloudflare/cloudflare-go` currently has breaking changes that have not been resolved in `cloudflare/terraform-provider-cloudflare`

Merging in will cause our fork to diverge temporarily. Cloudflare will need to address these breaking changes before they release their next version, which is when we can re-adopt their changes (via merge conflict resolution).

The fix I employed should resolve the compilation issues while we get this working on our side.

Incompatibility first introduced in:
* https://github.com/cloudflare/cloudflare-go/pull/880
* https://github.com/cloudflare/cloudflare-go/pull/878