### PR TITLE
support for cloudflare_logpush_job kind attribute

### DIFF
--- a/internal/provider/resource_cloudflare_logpush_job.go
+++ b/internal/provider/resource_cloudflare_logpush_job.go
@@ -63,6 +63,7 @@ func getJobFromResource(d *schema.ResourceData) (cloudflare.LogpushJob, *AccessI
 	job := cloudflare.LogpushJob{
 		ID:                 id,
 		Enabled:            d.Get("enabled").(bool),
+		Kind:               d.Get("kind").(string),
 		Name:               d.Get("name").(string),
 		Dataset:            d.Get("dataset").(string),
 		LogpullOptions:     d.Get("logpull_options").(string),
@@ -130,6 +131,7 @@ func resourceCloudflareLogpushJobRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	d.Set("name", job.Name)
+	d.Set("kind", job.Kind)
 	d.Set("enabled", job.Enabled)
 	d.Set("logpull_options", job.LogpullOptions)
 	d.Set("destination_conf", job.DestinationConf)

--- a/internal/provider/schema_cloudflare_logpush_job.go
+++ b/internal/provider/schema_cloudflare_logpush_job.go
@@ -26,6 +26,12 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Whether to enable the job.",
 		},
+		"kind": {
+			Type:     schema.TypeString,
+			Optional: true,
+			// TODO: update list of valid values when known.
+			Description: "The kind of logpush job to create. Valid values are \"edge\" or \"\".",
+		},
 		"name": {
 			Type:        schema.TypeString,
 			Optional:    true,


### PR DESCRIPTION
this PR provides early availability for the kind attribute on the cloudflare_logpush_job resource

cloudflare/cloudflare-go#936 will need to land in order to PR this upstream

depends on #51 