### PR TITLE
validate logpush job name

### DIFF
--- a/internal/provider/schema_cloudflare_logpush_job.go
+++ b/internal/provider/schema_cloudflare_logpush_job.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -33,9 +34,10 @@ func resourceCloudflareLogpushJobSchema() map[string]*schema.Schema {
 			Description: "The kind of logpush job to create. Valid values are \"edge\" or \"\".",
 		},
 		"name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "The name of the logpush job to create. Must match the regular expression `^[a-zA-Z0-9\\-\\.]*$`.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9.-]+$`), "must contain only alphanumeric characters, hyphens, and periods"),
+			Description:  "The name of the logpush job to create.",
 		},
 		"dataset": {
 			Type:         schema.TypeString,


### PR DESCRIPTION
adds a validation to the logpush job name (so that it's caught when planning instead of during apply)

expedites access to cloudflare/terraform-provider-cloudflare#1717