### PR TITLE
DRAFT: Update to upstream's version 3.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Cloudflare Terraform Provider
 
+## Developing locally
+
+### Initial setup
+
+Run `dev clone terraform-provider-cloudflare` and place the following snippet in `~/.terraformrc`:
+```
+provider_installation {
+  dev_overrides {
+    "cloudflare/cloudflare" = "/Users/<your_name>/src/github.com/Shopify/terraform-provider-cloudflare"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+```
+
+### Testing your changes
+
+After making your changes, run `make build-dev` and run `terraform init && terraform plan` in the terraform project using the module.
+
 ## Quickstarts
 
 - [Getting started with Cloudflare and Terraform](https://developers.cloudflare.com/terraform/installing)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudflare/terraform-provider-cloudflare
 
 go 1.17
 
+replace github.com/cloudflare/cloudflare-go => github.com/shopify/cloudflare-go v0.7.4-0.20221130172528-988fe3b8e803
+
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/cloudflare-go v0.57.1 h1:c9OhL/WusagBirP+CIJeCqS7OjT9kiWjtJv4lwxp3ZM=
-github.com/cloudflare/cloudflare-go v0.57.1/go.mod h1:cD8AqNMMaL1A0Sj9XKo3Xu9ZVHwHqgXJofb1ya210GQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
@@ -233,6 +231,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shopify/cloudflare-go v0.7.4-0.20221130172528-988fe3b8e803 h1:/7eqeyJgD+jt6ACIXMVEmgjU/exnr8c5S1oNqySRf0E=
+github.com/shopify/cloudflare-go v0.7.4-0.20221130172528-988fe3b8e803/go.mod h1:2N8L4vv3eobUgkB41tSiIJWRK4u/jJsK3IQz3EgFS+8=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -249,7 +249,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
+github.com/urfave/cli/v2 v2.23.5/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -286,6 +286,8 @@ func New(version string) func() *schema.Provider {
 				"cloudflare_zone_lockdown":                          resourceCloudflareZoneLockdown(),
 				"cloudflare_zone_settings_override":                 resourceCloudflareZoneSettingsOverride(),
 				"cloudflare_zone":                                   resourceCloudflareZone(),
+				/* Non Public below this line*/
+				"cloudflare_zone_cache_tiered_cache_smart_topology": resourceCloudflareZoneCacheTieredCacheSmartTopology(),
 			},
 		}
 

--- a/internal/provider/resource_cloudflare_zone_cache_tiered_cache_smart_topology.go
+++ b/internal/provider/resource_cloudflare_zone_cache_tiered_cache_smart_topology.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceCloudflareZoneCacheTieredCacheSmartTopology() *schema.Resource {
+	return &schema.Resource{
+		Schema:        resourceCloudflareZoneCacheTieredCacheSmartTopologySchema(),
+		CreateContext: resourceCloudflareZoneCacheTieredCacheSmartTopologyUpdate,
+		ReadContext:   resourceCloudflareZoneCacheTieredCacheSmartTopologyRead,
+		UpdateContext: resourceCloudflareZoneCacheTieredCacheSmartTopologyUpdate,
+		DeleteContext: resourceCloudflareZoneCacheTieredCacheSmartTopologyDelete,
+	}
+}
+
+func resourceCloudflareZoneCacheTieredCacheSmartTopologyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+
+	tflog.Info(ctx, fmt.Sprintf("Reading Zone Cache TieredCacheSmartTopology %q", d.Id()))
+
+	topology, err := client.TieredCacheSmartTopology(ctx, d.Id())
+
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP status 404") {
+			tflog.Info(ctx, fmt.Sprintf("Zone Cache TieredCacheSmartTopology for zone %q not found", d.Id()))
+			d.SetId("")
+			return nil
+		} else {
+			return diag.FromErr(fmt.Errorf("error reading cache TieredCacheSmartTopology for zone %q: %w", d.Id(), err))
+		}
+	}
+
+	value := topology.Value
+
+	if err := d.Set("value", value); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set value: %w", err))
+	}
+
+	return nil
+}
+
+func parseValue(value string) (cloudflare.TieredCacheSmartTopologyValue, error) {
+	switch value {
+	case "on":
+		return cloudflare.TieredCacheSmartTopologyOn, nil
+	case "off":
+		return cloudflare.TieredCacheSmartTopologyOff, nil
+	default:
+		return cloudflare.TieredCacheSmartTopologyOff, errors.New("invalid value for TieredCacheSmartTopologyValue")
+	}
+}
+
+func resourceCloudflareZoneCacheTieredCacheSmartTopologyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudflare.API)
+
+	zoneID := d.Get("zone_id").(string)
+	d.SetId(zoneID)
+
+	value, err := parseValue(d.Get("value").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	tflog.Info(ctx, fmt.Sprintf("Setting Zone Cache TieredCacheSmartTopology to struct: %+v for zone ID: %q", value, d.Id()))
+
+	_, err = client.UpdateTieredCacheSmartTopology(ctx, d.Id(), cloudflare.TieredCacheSmartTopologyUpdateOptions{Value: value})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error setting cache TieredCacheSmartTopology for zone %q: %w", d.Id(), err))
+	}
+
+	return resourceCloudflareZoneCacheTieredCacheSmartTopologyRead(ctx, d, meta)
+}
+
+func resourceCloudflareZoneCacheTieredCacheSmartTopologyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	tflog.Info(ctx, fmt.Sprintf("Deleting Zone Cache TieredCacheSmartTopology for zone ID: %q", d.Id()))
+	d.Set("value", cloudflare.TieredCacheSmartTopologyOff)
+
+	return resourceCloudflareZoneCacheTieredCacheSmartTopologyUpdate(ctx, d, meta)
+}

--- a/internal/provider/schema_cloudflare_zone_cache_tiered_cache_smart_topology.go
+++ b/internal/provider/schema_cloudflare_zone_cache_tiered_cache_smart_topology.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceCloudflareZoneCacheTieredCacheSmartTopologySchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"zone_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"value": {
+			Type:     schema.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"on",
+				"off",
+			}, false),
+		},
+	}
+}


### PR DESCRIPTION
Changelog can be found here: https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/CHANGELOG.md

Mainly for bringing in the new data source `cloudflare_load_balancer_pools` for https://github.com/Shopify/terraform-the-cloud/pull/15295/files

Draft until https://github.com/Shopify/cloudflare-go is also updated from current to v0.57.1 as noted in `go.mod`

Plan is to merge onto master then cut the tag rather than do it on master as it's my first time