### PR TITLE
v4.52.1-shopify (official) ?

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.52.1.3-shopify
+4.52.1-shopify


### PR DESCRIPTION
try to cut a "real" release - since terraform apparently doesn't support 4-level versions...


```
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider
│ terraform-private-registry.shopify.io/shopify/cloudflare: could not query provider registry for
│ terraform-private-registry.shopify.io/shopify/cloudflare: registry response includes invalid version string
│ "4.52.1.3-shopify": too many numbered portions; only three are allowed (major, minor, patch)
│
│ To see which modules are currently depending on terraform-private-registry.shopify.io/shopify/cloudflare and what
│ versions are specified, run the following command:
│     terraform providers
```